### PR TITLE
Add background color and image to main app

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,18 @@
+.container {
+  position: relative;
+  background-color: var(--off-white);
+  min-height: 100svh;
+  overflow: hidden;
+}
+
+.bgImageContainer {
+  position: relative;
+  height: 100svh;
+}
+
+.bgImageContainer img {
+  max-width: 100%;
+  max-height: 100%;
+  min-height: 100%;
+  object-fit: contain;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,14 @@
+import styles from "./App.module.css";
+import mbBgLight from "./assets/pattern-background-mobile-light.svg";
+
 function App() {
-  return <div>Clean app ready to start</div>;
+  return (
+    <div className={styles.container}>
+      <div className={styles.bgImageContainer}>
+        <img src={mbBgLight} alt="background pattern" />
+      </div>
+    </div>
+  );
 }
 
 export default App;


### PR DESCRIPTION
Adds background colour and image to the main app for mobile light view.

![Screenshot from 2024-07-29 13-57-44](https://github.com/user-attachments/assets/76e29876-7dea-4667-801a-47bf02b490d9)
![Screenshot from 2024-07-29 13-57-57](https://github.com/user-attachments/assets/e466b3d1-927f-482e-992b-f334b2a0b37d)
![Screenshot from 2024-07-29 13-58-41](https://github.com/user-attachments/assets/a690d5bc-285f-4d97-9b3c-696d8a8bf005)
