### PR TITLE
Add header component

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -6,21 +6,6 @@
   background-image: url("./assets/pattern-background-mobile-light.svg");
   background-size: cover;
   background-repeat: no-repeat;
-}
-
-.bgImageContainer {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 100svh;
-}
-
-.bgImageContainer img {
-  position: absolute;
-  max-width: 100%;
-  max-height: 100%;
-  min-height: 100%;
-  object-fit: contain;
+  padding-left: 24px;
+  padding-right: 24px;
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -3,14 +3,22 @@
   background-color: var(--off-white);
   min-height: 100svh;
   overflow: hidden;
+  background-image: url("./assets/pattern-background-mobile-light.svg");
+  background-size: cover;
+  background-repeat: no-repeat;
 }
 
 .bgImageContainer {
-  position: relative;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   height: 100svh;
 }
 
 .bgImageContainer img {
+  position: absolute;
   max-width: 100%;
   max-height: 100%;
   min-height: 100%;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import styles from "./App.module.css";
 import mbBgLight from "./assets/pattern-background-mobile-light.svg";
+import Header from "./components/Header/Header";
 
 function App() {
   return (
     <div className={styles.container}>
-      <div className={styles.bgImageContainer}>
+      {/* <div className={styles.bgImageContainer}>
         <img src={mbBgLight} alt="background pattern" />
-      </div>
+      </div> */}
+      <Header />
     </div>
   );
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,0 +1,51 @@
+.container {
+  position: relative;
+  z-index: 2;
+  margin-top: 16px;
+}
+.container p {
+  font-size: 18px;
+}
+.accessabilityIcon {
+  background-color: #f6e7ff;
+  padding: 12px;
+  border-radius: 4px;
+  margin-right: 16px;
+}
+
+.darkModeBtn {
+  position: relative;
+  width: 50px;
+  height: 30px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.darkModeBtn::before {
+  position: absolute;
+  content: "";
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background-color: var(--purple);
+  border-radius: 50px;
+  transition: background-color 0.3s ease;
+}
+
+.darkModeBtn::after {
+  position: absolute;
+  content: "";
+  top: 5px;
+  left: 5px;
+  height: 20px;
+  width: 20px;
+  background-color: var(--white);
+  border-radius: 50px;
+  transition: transform 0.3s ease;
+}
+
+.darkModeBtn.active::after {
+  transform: translateX(20px);
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -20,6 +20,7 @@
   background: transparent;
   border: none;
   cursor: pointer;
+  margin: 0px 8px;
 }
 
 .darkModeBtn::before {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,6 +3,8 @@ import styles from "./Header.module.css";
 import accessabilityImg from "../../assets/icon-accessibility.svg";
 import sunIcon from "../../assets/icon-sun-dark.svg";
 import moonIcon from "../../assets/icon-moon-dark.svg";
+import darkSun from "../../assets/icon-sun-light.svg";
+import darkMoon from "../../assets/icon-moon-light.svg";
 
 const Header = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -24,13 +26,13 @@ const Header = () => {
         <p>Accessibility</p>
       </div>
       <div className="flex-row items-center justify-between">
-        <img src={sunIcon} alt="sun icon" />
+        <img src={isDarkMode ? darkSun : sunIcon} alt="sun icon" />
         <button
           className={`${styles.darkModeBtn} ${isDarkMode ? styles.active : ""}`}
           onClick={toggleDarkMode}
           aria-label="Toggle dark mode"
         />
-        <img src={moonIcon} alt="moon icon" />
+        <img src={isDarkMode ? darkMoon : moonIcon} alt="moon icon" />
       </div>
     </div>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import styles from "./Header.module.css";
 import accessabilityImg from "../../assets/icon-accessibility.svg";
+import sunIcon from "../../assets/icon-sun-dark.svg";
+import moonIcon from "../../assets/icon-moon-dark.svg";
 
 const Header = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -21,11 +23,15 @@ const Header = () => {
         />
         <p>Accessibility</p>
       </div>
-      <button
-        className={`${styles.darkModeBtn} ${isDarkMode ? styles.active : ""}`}
-        onClick={toggleDarkMode}
-        aria-label="Toggle dark mode"
-      />
+      <div className="flex-row items-center justify-between">
+        <img src={sunIcon} alt="sun icon" />
+        <button
+          className={`${styles.darkModeBtn} ${isDarkMode ? styles.active : ""}`}
+          onClick={toggleDarkMode}
+          aria-label="Toggle dark mode"
+        />
+        <img src={moonIcon} alt="moon icon" />
+      </div>
     </div>
   );
 };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import styles from "./Header.module.css";
+import accessabilityImg from "../../assets/icon-accessibility.svg";
+
+const Header = () => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode(!isDarkMode);
+  };
+
+  return (
+    <div
+      className={`flex-row justify-between items-center ${styles.container}`}
+    >
+      <div className="flex-row items-center justify-start">
+        <img
+          className={styles.accessabilityIcon}
+          src={accessabilityImg}
+          alt="accessability icon"
+        />
+        <p>Accessibility</p>
+      </div>
+      <button
+        className={`${styles.darkModeBtn} ${isDarkMode ? styles.active : ""}`}
+        onClick={toggleDarkMode}
+        aria-label="Toggle dark mode"
+      />
+    </div>
+  );
+};
+
+export default Header;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "./Header.module.css";
 import accessabilityImg from "../../assets/icon-accessibility.svg";
 

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 }
 
 :root {
-  --puple: #a729f5;
+  --purple: #a729f5;
   --dark-grey: #313e51;
   --mid-grey: #3b4d66;
   --light-grey: #626c7f;
@@ -15,4 +15,26 @@
   --white: #fff;
   --green: #26d782;
   --red: #ee5454;
+}
+
+.flex-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.flex-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.justify-start {
+  justify-content: start;
 }


### PR DESCRIPTION
Adds mobile header including dark mode button. Button is not yet wired up, but is correctly animated. Includes dark and light mode version of sun and moon icons. 
![output](https://github.com/user-attachments/assets/2a73739f-3978-447f-b44e-d589f1a5390b)
