### PR TITLE
Add responsive sytles to header for desktop, tablet, and mobile

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,3 +9,17 @@
   padding-left: 24px;
   padding-right: 24px;
 }
+
+@media only screen and (min-width: 768px) {
+  .container {
+    padding-left: 64px;
+    padding-right: 64px;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .container {
+    padding-left: 140px;
+    padding-right: 140px;
+  }
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -3,9 +3,11 @@
   z-index: 2;
   margin-top: 16px;
 }
+
 .container p {
   font-size: 18px;
 }
+
 .accessabilityIcon {
   background-color: #f6e7ff;
   padding: 12px;
@@ -42,6 +44,29 @@
   left: 5px;
   height: 20px;
   width: 20px;
+  font-size: 18px;
+  background-color: white;
+}
+
+.darkModeBtn::before {
+  position: absolute;
+  content: "";
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background-color: var(--purple);
+  border-radius: 50px;
+  transition: background-color 0.3s ease;
+}
+
+.darkModeBtn::after {
+  position: absolute;
+  content: "";
+  top: 5px;
+  left: 5px;
+  height: 20px;
+  width: 20px;
   background-color: var(--white);
   border-radius: 50px;
   transition: transform 0.3s ease;
@@ -49,4 +74,20 @@
 
 .darkModeBtn.active::after {
   transform: translateX(20px);
+}
+
+@media only screen and (min-width: 768px) {
+  .container {
+    margin-top: 40px;
+  }
+
+  .container p {
+    font-size: 28px;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .container {
+    margin-top: 83px;
+  }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,6 +18,7 @@ const Header = () => {
       className={`flex-row justify-between items-center ${styles.container}`}
     >
       <div className="flex-row items-center justify-start">
+        <img src="" alt="" />
         <img
           className={styles.accessabilityIcon}
           src={accessabilityImg}


### PR DESCRIPTION
Adds responsive styles to the header, covering desktop, tablet and mobile breakpoints. 
![output](https://github.com/user-attachments/assets/bfd03742-638c-49a1-8c75-7d03e03d94af)
