### PR TITLE
adds active quiz state to header, and displays icon and text for quiz

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,19 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import styles from "./App.module.css";
 import Header from "./components/Header/Header";
 import { useTheme } from "./contexts/ThemeContext";
 import HomeScreen from "./components/HomeScreen/HomeScreen";
 
+export enum Quiz {
+  HTML = "HTML",
+  CSS = "CSS",
+  JS = "Javascript",
+  ACC = "Accessability",
+}
+
 const App = () => {
   const { darkMode } = useTheme();
+  const [activeQuiz, setActiveQuiz] = useState<Quiz | null>(null);
 
   useEffect(() => {
     console.log(darkMode);
@@ -19,7 +27,7 @@ const App = () => {
 
   return (
     <div className={styles.container}>
-      <Header />
+      <Header activeQuiz={activeQuiz} />
       <div className={styles.contentContainer}>
         <HomeScreen />
       </div>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -17,7 +17,6 @@
   height: 40px;
   padding: 5px;
   display: flex;
-  background-color: #f6e7ff;
   margin-right: 16px;
   border-radius: 4px;
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,27 +1,57 @@
 import styles from "./Header.module.css";
-import accessabilityImg from "../../assets/icon-accessibility.svg";
+import { useTheme } from "../../contexts/ThemeContext";
+import { Quiz } from "../../App";
+
+// QUIZ ICONS
+import htmlIcon from "../../assets/icon-html.svg";
+import cssIcon from "../../assets/icon-css.svg";
+import jsIcon from "../../assets/icon-js.svg";
+import accIcon from "../../assets/icon-accessibility.svg";
+
+// DARK MODE ICONS
 import sunIcon from "../../assets/icon-sun-dark.svg";
 import moonIcon from "../../assets/icon-moon-dark.svg";
 import darkSun from "../../assets/icon-sun-light.svg";
 import darkMoon from "../../assets/icon-moon-light.svg";
-import { useTheme } from "../../contexts/ThemeContext";
 
-const Header = () => {
+interface HeaderProps {
+  activeQuiz: Quiz | null;
+}
+
+const Header = ({ activeQuiz }: HeaderProps) => {
   const { darkMode, toggleDarkMode } = useTheme();
+
+  const quizIcon =
+    activeQuiz == Quiz.HTML
+      ? htmlIcon
+      : activeQuiz == Quiz.CSS
+      ? cssIcon
+      : activeQuiz == Quiz.JS
+      ? jsIcon
+      : activeQuiz == Quiz.ACC
+      ? accIcon
+      : "";
+
+  const iconColor =
+    activeQuiz == Quiz.HTML
+      ? "#FFF1E9"
+      : activeQuiz == Quiz.CSS
+      ? "#E0FDEF"
+      : activeQuiz == Quiz.JS
+      ? "#EBF0FF"
+      : activeQuiz == Quiz.ACC
+      ? "#F6E7FF"
+      : "transparent";
 
   return (
     <div
       className={`flex-row justify-between items-center ${styles.container}`}
     >
       <div className="flex-row items-center justify-start">
-        <div className={styles.iconContainer}>
-          <img
-            className={styles.accessabilityIcon}
-            src={accessabilityImg}
-            alt="accessability icon"
-          />
+        <div className={styles.iconContainer} style={{ background: iconColor }}>
+          <img className={styles.accessabilityIcon} src={quizIcon} alt="" />
         </div>
-        <p>Accessibility</p>
+        <p style={{ display: activeQuiz ? "" : "none" }}>{activeQuiz}</p>
       </div>
       <div className="flex-row items-center justify-between">
         <img src={darkMode ? darkSun : sunIcon} alt="sun icon" />


### PR DESCRIPTION
Tracks the active quiz state in the main app. 

Header now takes active quiz state and updates the quiz name and icon to match.

![output](https://github.com/user-attachments/assets/91d322f4-d359-473c-84af-0a869afd6cdf)
